### PR TITLE
Corrected minor typos in German

### DIFF
--- a/frameworks/base/core/res/res/values-de/mad_strings.xml
+++ b/frameworks/base/core/res/res/values-de/mad_strings.xml
@@ -15,9 +15,9 @@
      limitations under the License.
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="permlab_preventpower">override power key</string>
+    <string name="permlab_preventpower">Power-Taste ändern</string>
     <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
-    <string name="permdesc_preventpower">Allows an app to override the power key.</string>
+    <string name="permdesc_preventpower">Erlaubt Apps die Power-Taste zu ändern.</string>
 
     <!-- Button to reboot the phone in reboot menu -->
     <string name="reboot_reboot">Neustart</string>

--- a/frameworks/base/packages/SystemUI/res/values-de/mad_strings.xml
+++ b/frameworks/base/packages/SystemUI/res/values-de/mad_strings.xml
@@ -19,7 +19,7 @@
     <string name="quick_settings_reboot_label">Neustart</string>
 
     <!-- Quick Settings tiles -->
-    <string name="quick_settings_screenshot_label">Bildschrimfoto</string>
+    <string name="quick_settings_screenshot_label">Bildschirmfoto</string>
     <string name="quick_settings_sync_label">Sync</string>
     <string name="accessibility_quick_settings_sync_off">Sync aus</string>
     <string name="accessibility_quick_settings_sync_on">Sync an</string>
@@ -33,5 +33,5 @@
     <string name="accessibility_quick_settings_caffeine_on">Caffeine an</string>
 
     <!-- Screen pinning dialog description (for devices without navbar) -->
-    <string name="screen_pinning_description_no_navbar">Bleibt im vordergrund bis Ansicht durch Drücken und Halten von ZURÜCK verlassen wird.</string>
+    <string name="screen_pinning_description_no_navbar">Bleibt im Vordergrund bis Ansicht durch Drücken und Halten von ZURÜCK verlassen wird.</string>
 </resources>

--- a/packages/apps/Settings/res/values-de/mad_strings.xml
+++ b/packages/apps/Settings/res/values-de/mad_strings.xml
@@ -45,7 +45,7 @@
     <string name="default_time">Normal</string>
     <string name="custom_time">Benutzerdefiniert</string>
     <string name="dialog_delete_title">Löschen</string>
-    <string name="dialog_delete_message">Ausgewähltes element löschen?</string>
+    <string name="dialog_delete_message">Ausgewähltes Element löschen?</string>
 
     <!-- Values for the notification light pulse spinners -->
     <string name="pulse_length_always_on">Immer an</string>
@@ -184,7 +184,7 @@
     <string name="set_success_message">Angewendet</string>
     <string name="set_ok_text">OK</string>
     <string name="set_fail_title">Fehlgeschlagen</string>
-    <string name="set_fail_message">Anwenden fehlgeschalgen</string>
+    <string name="set_fail_message">Anwenden fehlgeschlagen</string>
     <string name="set_fail_text">Schließen</string>
     <string name="reset_title">Zurücksetzen</string>
     <string name="reset_message">Auf Standard zurücksetzen?</string>


### PR DESCRIPTION
Summary:

core: translated remaining strings

SystemUI: fixed typo (Bildschrimfoto->Bildschirmfoto)

Settings: fixed typos: fehlgeschalgen->fehlgeschlagen; element->Element